### PR TITLE
feat: Implement quest abandonment functionality (#24)

### DIFF
--- a/src/input/command_handlers.rs
+++ b/src/input/command_handlers.rs
@@ -131,7 +131,7 @@ impl CommandHandler for DefaultCommandHandler {
                 handle_quest_recommendations(quest_system, player, faction_system)
             }
             ParsedCommand::QuestAbandon { quest_id } => {
-                handle_quest_abandon(quest_id, quest_system)
+                handle_quest_abandon(quest_id, quest_system, faction_system)
             }
 
             ParsedCommand::Equip { crystal } => {
@@ -1275,9 +1275,8 @@ fn handle_quest_recommendations(quest_system: &QuestSystem, player: &Player, fac
 }
 
 /// Handle quest abandon command
-fn handle_quest_abandon(_quest_id: String, _quest_system: &mut QuestSystem) -> GameResult<String> {
-    // Implementation would mark quest as abandoned and clean up progress
-    Ok("Quest abandonment feature not yet implemented.".to_string())
+fn handle_quest_abandon(quest_id: String, quest_system: &mut QuestSystem, faction_system: &mut FactionSystem) -> GameResult<String> {
+    quest_system.abandon_quest(&quest_id, faction_system)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Implements quest abandonment system with faction reputation consequences.

### Quest Abandonment
- ✅ `quest abandon <quest_id>` - Abandon active quests
- ✅ Faction reputation penalties (50% of expected reward)
- ✅ Tutorial quest protection (cannot abandon)
- ✅ Status validation (only in-progress quests)
- ✅ Clear consequence messaging

### Business Logic

**Abandonment Rules:**
- Only quests with `InProgress` status can be abandoned
- Tutorial quests cannot be abandoned (educational requirement)
- Faction penalties only apply for quests where they expected help
- Penalty is 50% of the positive faction reward
- Quest marked as `Abandoned` with completion timestamp

**Faction Consequences:**
- Positive faction effects → Apply -50% penalty
- Negative/neutral effects → No penalty
- Clear messaging shows all reputation changes
- Integrates with existing FactionSystem

**Re-Availability:**
- Abandoned quests remain in quest definitions
- Can be re-started in future (if requirements met)
- Message informs player of future availability

## Technical Implementation

**New Method:**
```rust
pub fn abandon_quest(&mut self, quest_id: &str, faction_system: &mut FactionSystem) -> GameResult<String>
```

**Features:**
- Quest existence validation
- Status checking (InProgress only)
- Tutorial category protection
- Faction penalty calculation and application
- Comprehensive result messaging

**Integration:**
- Uses `FactionSystem::modify_reputation()`
- Updates `QuestProgress::status` to `Abandoned`
- Sets `completed_at` timestamp

## Testing

Added 4 comprehensive unit tests:

1. ✅ test_abandon_quest - Successful abandonment
2. ✅ test_cannot_abandon_tutorial - Tutorial protection works
3. ✅ test_cannot_abandon_non_active_quest - Validation prevents invalid abandonment
4. ✅ test_abandon_quest_with_faction_penalty - Reputation penalties applied correctly

**Test Results:**
- All 244 tests passing (4 new tests)
- Zero compilation warnings  
- Zero clippy errors
- 100% test pass rate

## Acceptance Criteria

From Issue #24:
- ✅ `quest abandon <quest_id>` works
- ✅ Quest removed from active list (status = Abandoned)
- ✅ Appropriate consequences applied (faction penalties)
- ✅ Can re-start quest later (quest still available)
- ✅ Clear explanation of consequences  
- ✅ Tests for abandonment logic

## Edge Cases

- ✅ Abandon tutorial quest → "Tutorial quests cannot be abandoned" error
- ✅ Abandon non-started quest → "You haven't started" error
- ✅ Abandon completed quest → Status validation error
- ✅ Quest with no faction effects → "No faction reputation penalties" message
- ✅ Quest with negative effects → No penalty (wasn't helping them anyway)

## Example Usage

```
> quest abandon forbidden_research
You have abandoned the quest: Forbidden Research

• MagistersCouncil faction reputation: -15 (abandonment penalty)
• OrderOfHarmony faction reputation: -5 (abandonment penalty)

The quest may become available again in the future.

> quest abandon basic_introduction  
Error: Tutorial quests cannot be abandoned. Please complete them to learn the game.

> quest abandon some_quest
Error: You haven't started the quest 'Some Quest'
```

## Files Changed

- `src/systems/quests.rs` - Added abandon_quest() method (+88 lines including tests)
- `src/input/command_handlers.rs` - Updated handler to pass FactionSystem

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)